### PR TITLE
Remove codefmtlib->codefmt dependency

### DIFF
--- a/addon-info.json
+++ b/addon-info.json
@@ -4,7 +4,6 @@
   "author": "Google",
   "repository": {"type": "git", "url": "git://github.com/google/vim-codefmtlib"},
   "dependencies": {
-    "maktaba": {"type": "git", "url": "git://github.com/google/vim-maktaba"},
-    "codefmt": {"type": "git", "url": "git://github.com/google/vim-codefmt"}
+    "maktaba": {"type": "git", "url": "git://github.com/google/vim-maktaba"}
   }
 }


### PR DESCRIPTION
Remove the dependency from codefmtlib to codefmt, since there's a dependency the other way and deps going both ways aren't the best (or safest) way to express the relationship between the two.