### PR TITLE
Shorten too-long plugin description to work around google/vimdoc#83

### DIFF
--- a/addon-info.json
+++ b/addon-info.json
@@ -1,6 +1,6 @@
 {
   "name": "codefmtlib",
-  "description": "Interface library for registering syntax-aware code formatters.",
+  "description": "Interface library for codefmt and formatter integrations.",
   "author": "Google",
   "repository": {"type": "git", "url": "git://github.com/google/vim-codefmtlib"},
   "dependencies": {

--- a/doc/codefmtlib.txt
+++ b/doc/codefmtlib.txt
@@ -1,5 +1,5 @@
-*codefmtlib.txt*	Syntax-aware code formatting
-                                                                  *codefmtlib*
+*codefmtlib.txt*	Interface library for codefmt and formatter integrations.
+Google                                                            *codefmtlib*
 
 ==============================================================================
 CONTENTS                                                 *codefmtlib-contents*


### PR DESCRIPTION
Fixes #3.